### PR TITLE
[WIP] Custom colorz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- A `utils` submodule with `hex_to_rgb` function. Yes, custom colors coming!
+
 ### Fixed
 - Fixed old reference name in a test, which was causing builds to fail.
 - Many many readme fixes.

--- a/hues/colortable.py
+++ b/hues/colortable.py
@@ -4,13 +4,13 @@ Source: http://ascii-table.com/ansi-escape-sequences.php
 '''
 from collections import namedtuple
 
-ANSIColors = namedtuple('ANSIColors', [
+ANSIColors = namedtuple('ANSIColors', (
   'black', 'red', 'green', 'yellow',
   'blue', 'magenta', 'cyan', 'white',
-])
-ANSIStyles = namedtuple('ANSIStyles', [
+))
+ANSIStyles = namedtuple('ANSIStyles', (
   'reset', 'bold', 'italic', 'underline', 'defaultfg', 'defaultbg',
-])
+))
 
 # Style Codes
 STYLE = ANSIStyles(0, 1, 3, 4, 39, 49)
@@ -25,6 +25,10 @@ HI_BG = ANSIColors(*range(100, 108))
 
 # Terminal sequence format
 SEQ = '\033[%sm'
+
+# Extended ANSI Foreground and Background Sequence format
+XFG_SEQ = '38;2;{r};{g};{b}'
+XBG_SEQ = '48;2;{r};{g};{b}'
 
 
 def __gen_keywords__(*args, **kwargs):
@@ -42,3 +46,6 @@ def __gen_keywords__(*args, **kwargs):
   return namedtuple('ANSISequences', fields)(*values)
 
 KEYWORDS = __gen_keywords__(STYLE, FG, bg=BG, bright=HI_FG, bg_bright=HI_BG)
+
+
+__all__ = ('FG', 'BG', 'HI_FG', 'HI_BG', 'KEYWORDS', 'XFG_SEQ', 'XBG_SEQ')

--- a/hues/utils.py
+++ b/hues/utils.py
@@ -1,0 +1,21 @@
+'''Implements helper utilities.'''
+from collections import namedtuple
+
+RGB = namedtuple('RGB', ('red', 'green', 'blue'))
+
+
+def hex_to_rgb(color):
+  '''Convert hex color string to a RGB tuple
+
+  >>> hex_to_rgb('#FFF')
+  RGB(red=255, green=255, blue=255)
+  '''
+  if not color.startswith('#') or len(color) not in (4, 7):
+    raise ValueError('Expected a hex coded color value, got `{0}`'.format(color))
+
+  hexcode = color[1:]
+  if len(hexcode) == 3:
+    hexcode = ''.join([x * 2 for x in hexcode])
+
+  cvals = (int(hexcode[i * 2 : (i + 1) * 2], 16) for i in range(0, 3))
+  return RGB(*cvals)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,21 @@
+from hues.utils import hex_to_rgb
+
+
+def test_hex_to_rgb_usage():
+  assert hex_to_rgb('#FFF') == (255, 255, 255)
+  assert hex_to_rgb('#FFFFFF') == (255, 255, 255)
+  assert hex_to_rgb('#2E2E2E') == (46, 46, 46)
+  assert hex_to_rgb('#AABBBB') == (170, 187, 187)
+  assert hex_to_rgb('#8B7E66') == (139, 126, 102)
+
+
+def test_hex_to_rgb_exceptions():
+  try:
+    hex_to_rgb('TROLL!')
+  except ValueError:
+    pass
+
+  try:
+    hex_to_rgb('#TROLLL')
+  except ValueError:
+    pass


### PR DESCRIPTION
This PR will be the addition in version `0.3.0`.

- [ ] Fix the _really_ awkward API to provide custom color codes.
- [ ] Moar colorz! Add ability to provide colors via hex strings.
- [ ] Windoz support.
- [ ] Actually detect if we're writing to a terminal which declares itself as `x-term`.

Possibly, but low priority:
- [ ] Add ability (again, less awkward API) to delete stuff, so we can have:
- [ ] Progress! No, not competing with lovely `tqdm`, rather, just adding ability to have a `tick` mark or something in the front to denote it as done. Handy, right?